### PR TITLE
Update syntax for Cairo 0.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "highlightjs-cairo",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "highlightjs-cairo",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "highlight.js": "^11.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "highlightjs-cairo",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "highlight.js syntax definition for Cairo",
   "main": "src/index.js",
   "files": [

--- a/src/languages/cairo.js
+++ b/src/languages/cairo.js
@@ -1,6 +1,7 @@
 const python = require('highlight.js/lib/languages/python');
 
 function hljsDefineCairo(hljs) {
+  const regex = hljs.regex;
   const cairoLanguage = python(hljs);
 
   const RESERVED_WORDS = [
@@ -85,6 +86,18 @@ function hljsDefineCairo(hljs) {
   }
 
   Object.assign(cairoLanguage.keywords, KEYWORDS);
+
+  const comment = cairoLanguage.contains.find(element => element.className === 'comment');
+  if (comment !== undefined) {
+    comment.begin = regex.lookahead(/\/\//);
+    comment.contains = [
+      {
+        begin: /\/\//,
+        end: /\b\B/,
+        endsWithParent: true
+      }
+    ];
+  }
 
   Object.assign(cairoLanguage, {
     name: 'Cairo',

--- a/test.js
+++ b/test.js
@@ -97,7 +97,7 @@ it('annotations', function () {
 });
 
 it('comments', function () {
-  const comments = ['#hello', '# SPDX-License-Identifier: MIT'];
+  const comments = ['//hello', '// SPDX-License-Identifier: MIT'];
 
   for (const comment of comments) {
     assert.deepEqual(getTokens(comment), [['comment', comment]]);


### PR DESCRIPTION
- Override comment syntax from `#` to `//`