### PR TITLE
Fix: AsciiDoc Callouts require highlight.js 9.18.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
-        "highlight.js": "^11.0.0"
+        "highlight.js": "^9.18.3"
       },
       "devDependencies": {
         "mocha": "^6.2.1",
@@ -568,11 +568,13 @@
       }
     },
     "node_modules/highlight.js": {
-      "version": "11.6.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.6.0.tgz",
-      "integrity": "sha512-ig1eqDzJaB0pqEvlPVIpSSyMaO92bH1N2rJpLMN/nX396wTpDA4Eq0uK+7I/2XG17pFaaKE0kjV/XPeGt7Evjw==",
+      "version": "9.18.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.3.tgz",
+      "integrity": "sha512-zBZAmhSupHIl5sITeMqIJnYCDfAEc3Gdkqj65wC1lpI468MMQeeQkhcIAvk+RylAkxrCcI9xy9piHiXeQ1BdzQ==",
+      "deprecated": "Version no longer supported. Upgrade to @latest",
+      "dev": true,
       "engines": {
-        "node": ">=12.0.0"
+        "node": "*"
       }
     },
     "node_modules/inflight": {
@@ -1804,9 +1806,10 @@
       "dev": true
     },
     "highlight.js": {
-      "version": "11.6.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.6.0.tgz",
-      "integrity": "sha512-ig1eqDzJaB0pqEvlPVIpSSyMaO92bH1N2rJpLMN/nX396wTpDA4Eq0uK+7I/2XG17pFaaKE0kjV/XPeGt7Evjw=="
+      "version": "9.18.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.3.tgz",
+      "integrity": "sha512-zBZAmhSupHIl5sITeMqIJnYCDfAEc3Gdkqj65wC1lpI468MMQeeQkhcIAvk+RylAkxrCcI9xy9piHiXeQ1BdzQ==",
+      "dev": true
     },
     "inflight": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
     "parse5": "^5.1.0"
   },
   "dependencies": {
-    "highlight.js": "^11.0.0"
+    "highlight.js": "^9.18.3"
   }
 }


### PR DESCRIPTION
This PR addresses issue #3.

AsciiDoc provides callouts, making it easy to document code examples. For example, see Example 1 in [Callouts](https://docs.asciidoctor.org/asciidoc/latest/verbatim/callouts/) in the Asciidoctor docs.

As per [this thread in the Antora support channel](https://antora.zulipchat.com/#narrow/stream/282400-users/topic/Callouts.3A.20Where.20are.20the.20circled.20numbers.20defined.3F), highlight.js needs to be no greater than v9.18.3.

highlightjs-cairo uses [highlight.js 11.0 in package.json](https://github.com/OpenZeppelin/highlightjs-cairo/blob/5537dd59740f986427d037d40b9121aadbe0b160/package.json#L34), and 11.0 and 11.6.0 in package-lock.json.

The lines that I changed in package.json and package-lock.json were copied from the Antora default UI.