### PR TITLE
Support Highlight.js v9 in addition to v11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## Unreleased
+## 0.4.0
 
-- Support Highlight.js v9 in addition to v11.
+- Support Highlight.js v9 in addition to v11. ([#5](https://github.com/OpenZeppelin/highlightjs-cairo/pull/5))
 
 ## 0.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+## Unreleased
+
+- Support Highlight.js v9 in addition to v11.
+
+## 0.3.0
+
+- Support Cairo 1+. ([#2](https://github.com/OpenZeppelin/highlightjs-cairo/pull/2))
+
+## 0.2.0
+
+- Support Cairo 0.10. ([#1](https://github.com/OpenZeppelin/highlightjs-cairo/pull/1))
+
+## 0.1.0
+
+- Initial release.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2022-2023 zOS Global Limited
+Copyright (c) 2022-2024 zOS Global Limited
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/README.md
+++ b/README.md
@@ -22,8 +22,16 @@ Browser:
 </script>
 ```
 
-Node:
-   
+Node (Highlight.js v9):
+```javascript
+const hljs = require('highlight.js');
+const hljsDefineCairo = require('highlightjs-cairo');
+
+hljsDefineCairo(hljs);
+const highlighted = hljs.highlight('cairo', source).value;
+```
+
+Node (Highlight.js v11):
 ```javascript
 const hljs = require('highlight.js/lib/core');
 const hljsDefineCairo = require('highlightjs-cairo');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,15 @@
 {
   "name": "highlightjs-cairo",
-  "version": "0.2.0",
+  "version": "0.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "highlightjs-cairo",
-      "version": "0.2.0",
+      "version": "0.4.0",
       "license": "MIT",
-      "dependencies": {
-        "highlight.js": "^11.0.0"
-      },
       "devDependencies": {
+        "highlight.js": "^9.18.3",
         "mocha": "^6.2.1",
         "parse5": "^5.1.0"
       }
@@ -568,11 +566,13 @@
       }
     },
     "node_modules/highlight.js": {
-      "version": "11.6.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.6.0.tgz",
-      "integrity": "sha512-ig1eqDzJaB0pqEvlPVIpSSyMaO92bH1N2rJpLMN/nX396wTpDA4Eq0uK+7I/2XG17pFaaKE0kjV/XPeGt7Evjw==",
+      "version": "9.18.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.3.tgz",
+      "integrity": "sha512-zBZAmhSupHIl5sITeMqIJnYCDfAEc3Gdkqj65wC1lpI468MMQeeQkhcIAvk+RylAkxrCcI9xy9piHiXeQ1BdzQ==",
+      "deprecated": "Version no longer supported. Upgrade to @latest",
+      "dev": true,
       "engines": {
-        "node": ">=12.0.0"
+        "node": "*"
       }
     },
     "node_modules/inflight": {
@@ -1804,9 +1804,10 @@
       "dev": true
     },
     "highlight.js": {
-      "version": "11.6.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.6.0.tgz",
-      "integrity": "sha512-ig1eqDzJaB0pqEvlPVIpSSyMaO92bH1N2rJpLMN/nX396wTpDA4Eq0uK+7I/2XG17pFaaKE0kjV/XPeGt7Evjw=="
+      "version": "9.18.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.3.tgz",
+      "integrity": "sha512-zBZAmhSupHIl5sITeMqIJnYCDfAEc3Gdkqj65wC1lpI468MMQeeQkhcIAvk+RylAkxrCcI9xy9piHiXeQ1BdzQ==",
+      "dev": true
     },
     "inflight": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "highlightjs-cairo",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "highlight.js syntax definition for Cairo",
   "main": "src/index.js",
   "files": [
@@ -27,10 +27,8 @@
   },
   "homepage": "https://github.com/OpenZeppelin/highlightjs-cairo#readme",
   "devDependencies": {
+    "highlight.js": "^9.18.3",
     "mocha": "^6.2.1",
     "parse5": "^5.1.0"
-  },
-  "dependencies": {
-    "highlight.js": "^11.0.0"
   }
 }

--- a/src/languages/cairo.js
+++ b/src/languages/cairo.js
@@ -1,4 +1,4 @@
-const rust = require('highlight.js/lib/languages/rust');
+const rust = require('./vendored/rust');
 
 function hljsDefineCairo(hljs) {
   const cairoLanguage = rust(hljs);
@@ -72,10 +72,9 @@ function hljsDefineCairo(hljs) {
   }
 
   const KEYWORDS = {
-    $pattern: /[A-Za-z]\w+|\w+_/,
-    keyword: MAIN_KEYWORDS,
-    literal: LITERALS,
-    type: TYPES,
+    keyword: MAIN_KEYWORDS.join(' '),
+    literal: LITERALS.join(' '),
+    type: TYPES.join(' '),
   };
 
   Object.assign(cairoLanguage.keywords, KEYWORDS);
@@ -91,15 +90,31 @@ function hljsDefineCairo(hljs) {
         begin: 'component!',
       },
       {
-        begin: [
-          /mod/,
-          /\s+/,
-          hljs.UNDERSCORE_IDENT_RE
+        className: 'class',
+        beginKeywords: 'mod', end: '{',
+        contains: [
+          hljs.inherit(hljs.UNDERSCORE_TITLE_MODE, {endsParent: true})
         ],
-        className: {
-          1: 'keyword',
-          3: 'title.class',
-        }
+      },
+      {
+        className: 'class',
+        beginKeywords: 'impl', end: ';',
+        contains: [
+          hljs.inherit(hljs.UNDERSCORE_TITLE_MODE, {endsParent: true})
+        ],
+      },
+      {
+        beginKeywords: 'let', end: ';',
+        contains: [
+          hljs.inherit({
+            className: 'variable',
+            begin: hljs.UNDERSCORE_IDENT_RE,
+            relevance: 0
+          },
+          {
+            endsParent: true
+          }),
+        ],
       },
     ]
   );

--- a/src/languages/vendored/LICENSE
+++ b/src/languages/vendored/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2006, Ivan Sagalaev.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/languages/vendored/rust.js
+++ b/src/languages/vendored/rust.js
@@ -1,0 +1,117 @@
+// From https://github.com/highlightjs/highlight.js/blob/9.18.5/src/languages/rust.js
+
+/*
+Language: Rust
+Author: Andrey Vlasovskikh <andrey.vlasovskikh@gmail.com>
+Contributors: Roman Shmatov <romanshmatov@gmail.com>, Kasper Andersen <kma_untrusted@protonmail.com>
+Website: https://www.rust-lang.org
+Category: common, system
+*/
+
+module.exports = function(hljs) {
+  var NUM_SUFFIX = '([ui](8|16|32|64|128|size)|f(32|64))\?';
+  var KEYWORDS =
+    'abstract as async await become box break const continue crate do dyn ' +
+    'else enum extern false final fn for if impl in let loop macro match mod ' +
+    'move mut override priv pub ref return self Self static struct super ' +
+    'trait true try type typeof unsafe unsized use virtual where while yield';
+  var BUILTINS =
+    // functions
+    'drop ' +
+    // types
+    'i8 i16 i32 i64 i128 isize ' +
+    'u8 u16 u32 u64 u128 usize ' +
+    'f32 f64 ' +
+    'str char bool ' +
+    'Box Option Result String Vec ' +
+    // traits
+    'Copy Send Sized Sync Drop Fn FnMut FnOnce ToOwned Clone Debug ' +
+    'PartialEq PartialOrd Eq Ord AsRef AsMut Into From Default Iterator ' +
+    'Extend IntoIterator DoubleEndedIterator ExactSizeIterator ' +
+    'SliceConcatExt ToString ' +
+    // macros
+    'assert! assert_eq! bitflags! bytes! cfg! col! concat! concat_idents! ' +
+    'debug_assert! debug_assert_eq! env! panic! file! format! format_args! ' +
+    'include_bin! include_str! line! local_data_key! module_path! ' +
+    'option_env! print! println! select! stringify! try! unimplemented! ' +
+    'unreachable! vec! write! writeln! macro_rules! assert_ne! debug_assert_ne!';
+  return {
+    aliases: ['rs'],
+    keywords: {
+      keyword:
+        KEYWORDS,
+      literal:
+        'true false Some None Ok Err',
+      built_in:
+        BUILTINS
+    },
+    lexemes: hljs.IDENT_RE + '!?',
+    illegal: '</',
+    contains: [
+      hljs.C_LINE_COMMENT_MODE,
+      hljs.COMMENT('/\\*', '\\*/', {contains: ['self']}),
+      hljs.inherit(hljs.QUOTE_STRING_MODE, {begin: /b?"/, illegal: null}),
+      {
+        className: 'string',
+        variants: [
+           { begin: /r(#*)"(.|\n)*?"\1(?!#)/ },
+           { begin: /b?'\\?(x\w{2}|u\w{4}|U\w{8}|.)'/ }
+        ]
+      },
+      {
+        className: 'symbol',
+        begin: /'[a-zA-Z_][a-zA-Z0-9_]*/
+      },
+      {
+        className: 'number',
+        variants: [
+          { begin: '\\b0b([01_]+)' + NUM_SUFFIX },
+          { begin: '\\b0o([0-7_]+)' + NUM_SUFFIX },
+          { begin: '\\b0x([A-Fa-f0-9_]+)' + NUM_SUFFIX },
+          { begin: '\\b(\\d[\\d_]*(\\.[0-9_]+)?([eE][+-]?[0-9_]+)?)' +
+                   NUM_SUFFIX
+          }
+        ],
+        relevance: 0
+      },
+      {
+        className: 'function',
+        beginKeywords: 'fn', end: '(\\(|<)', excludeEnd: true,
+        contains: [hljs.UNDERSCORE_TITLE_MODE]
+      },
+      {
+        className: 'meta',
+        begin: '#\\!?\\[', end: '\\]',
+        contains: [
+          {
+            className: 'meta-string',
+            begin: /"/, end: /"/
+          }
+        ]
+      },
+      {
+        className: 'class',
+        beginKeywords: 'type', end: ';',
+        contains: [
+          hljs.inherit(hljs.UNDERSCORE_TITLE_MODE, {endsParent: true})
+        ],
+        illegal: '\\S'
+      },
+      {
+        className: 'class',
+        beginKeywords: 'trait enum struct union', end: '{',
+        contains: [
+          hljs.inherit(hljs.UNDERSCORE_TITLE_MODE, {endsParent: true})
+        ],
+        illegal: '[\\w\\d]'
+      },
+      {
+        begin: hljs.IDENT_RE + '::',
+        keywords: {built_in: BUILTINS}
+      },
+      {
+        begin: '->'
+      }
+    ]
+  };
+};

--- a/test.js
+++ b/test.js
@@ -9,8 +9,7 @@ defineCairo(hljs);
 // Receives a Cairo snippet and returns an array of [type, text] tuples.
 // Type is the detected token type, and text the corresponding source text.
 function getTokens(source) {
-  const { value } = hljs.highlight(source, { language: 'cairo' });
-  const frag = parse5.parseFragment(value);
+  const frag = parse5.parseFragment(highlight(source));
 
   return frag.childNodes.map(function (node) {
     if (node.nodeName === '#text') {
@@ -24,6 +23,10 @@ function getTokens(source) {
       return [type, node.childNodes[0].value];
     }
   });
+}
+
+function highlight(source) {
+  return hljs.highlight('cairo', source).value;
 }
 
 it('numbers', function () {
@@ -63,12 +66,24 @@ it('strings', function () {
   }
 });
 
-it('keywords', function () {
-  const keywords = ['mod', 'use', 'fn', 'impl', 'ref'];
+it('keyword mod', function () {
+  assert.equal(highlight('mod Foo {}'), '<span class="hljs-class"><span class="hljs-keyword">mod</span> <span class="hljs-title">Foo</span></span> {}');
+});
 
-  for (const keyword of keywords) {
-    assert.deepEqual(getTokens(keyword), [['keyword', keyword]]);
-  }
+it('keyword use', function () {
+  assert.equal(highlight('use foo::Bar;'), '<span class="hljs-keyword">use</span> foo::Bar;');
+});
+
+it('keyword fn', function () {
+  assert.equal(highlight('fn foo() {}'), '<span class="hljs-function"><span class="hljs-keyword">fn</span> <span class="hljs-title">foo</span></span>() {}');
+});
+
+it('keyword impl', function () {
+  assert.equal(highlight('impl FooImpl = BarImpl;'), '<span class="hljs-class"><span class="hljs-keyword">impl</span> <span class="hljs-title">FooImpl</span></span> = BarImpl;');
+});
+
+it('keyword ref', function () {
+  assert.equal(highlight('ref self: ContractState'), '<span class="hljs-keyword">ref</span> self: ContractState');
 });
 
 it('literals', function () {


### PR DESCRIPTION
Fixes https://github.com/OpenZeppelin/highlightjs-cairo/issues/3

Removes the package dependency on highlight.js v11, and changes it to a devDependency on highlight.js v9.  This allows consuming packages to use either highlight.js v9 or v11 without version conflicts.

This PR removes the package dependency by vendoring the highlight.js v9 implementation of Rust's syntax which it extends from, then applies modifications in a way that is compatible with both v9 and v11.

Functionality for Cairo is mostly the same as before, with one notable difference: function invocations are no longer highlighted.  In v11, Rust implements this [here](https://github.com/highlightjs/highlight.js/blob/f47103d4f1ac1592c56904574d1fbf5bf2475605/src/languages/rust.js#L12), but this heavily relies on regexes and I did not find a way to implement the same type of behaviour for v9.  I think this is an acceptable omission.
See the following for an example (left is before, right is after which no longer highlights function invocations)
![without_function_invocations](https://github.com/OpenZeppelin/highlightjs-cairo/assets/29640130/a120a558-9e4c-417b-be12-167942451a43)
